### PR TITLE
Ss 91 cache speech files on the backend

### DIFF
--- a/backend/src/routers/s3.py
+++ b/backend/src/routers/s3.py
@@ -15,86 +15,95 @@ from .s3_constants import BUCKET_NAME_ENV_VAR, ACCESS_KEY_ENV_VAR, SECRET_KEY_EN
 router = APIRouter()
 load_dotenv(dotenv_path=".env.local")
 
-s3 = boto3.client('s3', \
-					aws_access_key_id=getenv(ACCESS_KEY_ENV_VAR), \
-					aws_secret_access_key=getenv(SECRET_KEY_ENV_VAR), \
-					region_name=getenv(AWS_REGION_ENV_VAR)
-				)
+s3 = boto3.client('s3',
+                  aws_access_key_id=getenv(ACCESS_KEY_ENV_VAR),
+                  aws_secret_access_key=getenv(SECRET_KEY_ENV_VAR),
+                  region_name=getenv(AWS_REGION_ENV_VAR)
+                  )
+
 
 class UploadFileToS3Model(BaseModel):
-	base64File: str 
-	file_name: str 
-	extension: str
-	force_unique: bool = True
+    base64File: str
+    file_name: str
+    extension: str
+    force_unique: bool = True
+
+
+def upload_file_to_s3_logic(file_binary: bytes, uploaded_file_name: str, force_unique: bool):
+    # prefix with uuid if user wants it to be unique
+    if force_unique:
+        uploaded_file_name = f"{uuid.uuid4().hex}-{uploaded_file_name}"
+
+    print('env bucket', getenv(BUCKET_NAME_ENV_VAR))
+
+    s3.upload_fileobj(BytesIO(file_binary), getenv(
+        BUCKET_NAME_ENV_VAR), uploaded_file_name)
+
 
 @router.post(UPLOAD_TO_S3_ROUTE)
 def upload_file_to_s3(body: UploadFileToS3Model):
-	"""Upload file to S3 bucket
+    """Upload file to S3 bucket
 
-	Args:
-		body (UploadFileToS3Model): Contains:
-		
-			base64File: str # base64 representation of the file
-			file_name: str  # file name (ex: base.16.png -> base.16)
-			extension: str  # extension (ex: base.16.png ->    .png)
-			force_unique: bool = True # Set to false if you want your file to be saved as the raw file name other wise system will prefix each file with a `uuidv4`
-			
-	Returns:
-		dict: contains generated filename and url. Filename depends on your params and bool (force_unique) from UploadFileToS3Model
-	"""
-	uploaded_file_name = f'{body.file_name}.{body.extension}'
+    Args:
+            body (UploadFileToS3Model): Contains:
 
-	# prefix with uuid if user wants it to be unique
-	if body.force_unique: 
-		uploaded_file_name = f"{uuid.uuid4().hex}-{uploaded_file_name}"
+                    base64File: str # base64 representation of the file
+                    file_name: str  # file name (ex: base.16.png -> base.16)
+                    extension: str  # extension (ex: base.16.png ->    .png)
+                    force_unique: bool = True # Set to false if you want your file to be saved as the raw file name other wise system will prefix each file with a `uuidv4`
 
-	file_binary = b64decode(body.base64File)
-	
-	print('env bucket', getenv(BUCKET_NAME_ENV_VAR))
-	
-	s3.upload_fileobj(BytesIO(file_binary), getenv(BUCKET_NAME_ENV_VAR), uploaded_file_name)
+    Returns:
+            dict: contains generated filename and url. Filename depends on your params and bool (force_unique) from UploadFileToS3Model
+    """
+    uploaded_file_name = f'{body.file_name}.{body.extension}'
 
-	return {
-		"message": "uploaded",
-		"filename": uploaded_file_name,
-		"url": f'{getenv(OBJECT_URL_ENV_VAR)}/{uploaded_file_name}'
-	}
+    upload_file_to_s3_logic(
+        b64decode(body.base64File), uploaded_file_name, body.force_unique)
+
+    return {
+        "message": "uploaded",
+        "filename": uploaded_file_name,
+        "url": f'{getenv(OBJECT_URL_ENV_VAR)}/{uploaded_file_name}'
+    }
+
+
+def get_file_from_s3_logic(filename: str, get_url: bool = False):
+    try:
+        response = s3.get_object(
+            Bucket=getenv(BUCKET_NAME_ENV_VAR),
+            Key=filename,
+        )
+
+        if get_url:
+            return {"url": f'{getenv(OBJECT_URL_ENV_VAR)}/{filename}'}
+
+        # Get the object content to stream it to user
+        object_content = response['Body'].iter_chunks()
+        object_content_type = response['ContentType']
+
+        return (object_content, object_content_type)
+    except s3.exceptions.NoSuchKey:
+        # Handle the case when the specified object is not found
+        raise HTTPException(status_code=404, detail="Object not found in S3")
+
 
 @router.get(GET_FROM_S3_ROUTE)
-def get_file_from_s3(filename: str, get_url: bool=False):
-	"""get file upload to s3 if possible
+def get_file_from_s3(filename: str, get_url: bool = False):
+    """get file upload to s3 if possible
 
-	Args:
-		filename (str): File name to GET
-		get_url (bool, optional): Returns the url instead of object. Defaults to False.
+    Args:
+            filename (str): File name to GET
+            get_url (bool, optional): Returns the url instead of object. Defaults to False.
 
-	Raises:
-		HTTPException: `filename` is not a valid `Key` in S3 bucket.
- 
-	Returns:
-		dict["url":, str] : if get_url is `true` it will return a `{url: "..."}`
-		StreamingResponse : if get_url is `false` it will return the literal object
-	"""
-	try:
-		response = s3.get_object(
-			Bucket=getenv(BUCKET_NAME_ENV_VAR),
-			Key=filename,
-		)
+    Raises:
+            HTTPException: `filename` is not a valid `Key` in S3 bucket.
 
-		if get_url: 
-			return { "url": f'{getenv(OBJECT_URL_ENV_VAR)}/{filename}' }
-
-		# Get the object content to stream it to user
-		object_content = response['Body'].iter_chunks()
-		object_content_type = response['ContentType']
-
-		# Create a StreamingResponse to send the content as a stream (in memory)
-		# https://stackoverflow.com/questions/69617252/response-file-stream-from-s3-fastapi
-		return StreamingResponse(
-			content=object_content,
-			media_type=object_content_type,  # Set the based on s3 resp
-		)
-
-	except s3.exceptions.NoSuchKey:
-		# Handle the case when the specified object is not found
-		raise HTTPException(status_code=404, detail="Object not found in S3")
+    Returns:
+            dict["url":, str] : if get_url is `true` it will return a `{url: "..."}`
+            StreamingResponse : if get_url is `false` it will return the literal object
+    """
+    (object_content, object_content_type) = get_file_from_s3_logic(filename, get_url)
+    return StreamingResponse(
+        content=object_content,
+        media_type=object_content_type,  # Set the based on s3 resp
+    )

--- a/backend/src/routers/test_tts.py
+++ b/backend/src/routers/test_tts.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+import requests
+import requests_mock
+
+from .tts import TTS_ROUTE, router, get_config, get_session
+
+
+MOCK_TTS_ENDPOINT = 'mock://tts.com'
+MOCK_TEXT = 'exampledata'
+
+
+def mock_get_config() -> dict:
+    return {
+        'TTS_API_KEY': '',
+        'TTS_API_URL': MOCK_TTS_ENDPOINT
+    }
+
+
+# https://pypi.org/project/requests-mock/
+def mock_get_session() -> dict:
+    session = requests.Session()
+    adapter = requests_mock.Adapter()
+    session.mount(MOCK_TTS_ENDPOINT, adapter)
+    adapter.register_uri('POST', MOCK_TTS_ENDPOINT, text=MOCK_TEXT)
+    return session
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides.update(
+        {get_config: mock_get_config,
+         get_session: mock_get_session}
+    )
+
+    return TestClient(app)
+
+
+def test_tts(client: TestClient):
+    """Ensure that the client calls the correct endpoint and returns the
+       correct value."""
+    response = client.get(f"{TTS_ROUTE}?phrase=phrase")
+    assert response.status_code == 200
+    assert response.text == MOCK_TEXT

--- a/backend/src/routers/test_tts.py
+++ b/backend/src/routers/test_tts.py
@@ -1,14 +1,20 @@
-from fastapi import FastAPI
+from collections import OrderedDict
+from unittest.mock import Mock
+
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 import pytest
 import requests
 import requests_mock
 
-from .tts import TTS_ROUTE, router, get_config, get_session
+from . import tts
+
+from .s3 import get_file_from_s3_logic, upload_file_to_s3_logic
 
 
 MOCK_TTS_ENDPOINT = 'mock://tts.com'
-MOCK_TEXT = 'exampledata'
+MOCK_AUDIO_BYTES = b'123456789'
+MOCK_AUDIO_BYTES_STR = str(MOCK_AUDIO_BYTES)[2:-1]
 
 
 def mock_get_config() -> dict:
@@ -23,25 +29,108 @@ def mock_get_session() -> dict:
     session = requests.Session()
     adapter = requests_mock.Adapter()
     session.mount(MOCK_TTS_ENDPOINT, adapter)
-    adapter.register_uri('POST', MOCK_TTS_ENDPOINT, text=MOCK_TEXT)
+    adapter.register_uri('POST', MOCK_TTS_ENDPOINT, text=MOCK_AUDIO_BYTES_STR)
     return session
 
 
 @pytest.fixture
 def client() -> TestClient:
     app = FastAPI()
-    app.include_router(router)
+    app.include_router(tts.router)
     app.dependency_overrides.update(
-        {get_config: mock_get_config,
-         get_session: mock_get_session}
+        {tts.get_config: mock_get_config,
+         tts.get_session: mock_get_session}
     )
 
     return TestClient(app)
 
 
-def test_tts(client: TestClient):
-    """Ensure that the client calls the correct endpoint and returns the
-       correct value."""
-    response = client.get(f"{TTS_ROUTE}?phrase=phrase")
+def test_tts_s3(client: TestClient):
+    """Make sure that, in the case that the audio exists on S3, that
+       it is returned as-is from S3."""
+    mock_s3_get = Mock()
+    mock_s3_get.return_value = (MOCK_AUDIO_BYTES.partition(b'5'), None)
+    tts.get_file_from_s3_logic = mock_s3_get
+
+    response = client.get(f"{tts.TTS_ROUTE}?phrase=phrase")
+
     assert response.status_code == 200
-    assert response.text == MOCK_TEXT
+    assert response.text == MOCK_AUDIO_BYTES_STR
+
+
+def test_tts_no_s3(client: TestClient):
+    """Make sure that, in the case that there is an error retrieving a phrase
+       from S3, that the endpoint turns around and calls elevenlabs, uploads
+       the new audio data, and returns the audio data."""
+    mock_s3_get = Mock()
+    mock_s3_get.side_effect = HTTPException(422)
+    tts.get_file_from_s3_logic = mock_s3_get
+
+    mock_s3_upload = Mock()
+    tts.upload_file_to_s3_logic = mock_s3_upload
+
+    response = client.get(f"{tts.TTS_ROUTE}?phrase=phrase")
+
+    mock_s3_upload.assert_called_once()
+    assert response.status_code == 200
+    assert response.text == MOCK_AUDIO_BYTES_STR
+
+
+def test_tts_no_s3_and_upload_fails(client: TestClient):
+    """Make sure that, in the case that there is an error retrieving a phrase
+       from S3, that the endpoint turns around and calls elevenlabs, tries
+       to upload only for it to fail, and returns the audio regardless."""
+    mock_s3_get = Mock()
+    mock_s3_get.side_effect = HTTPException(422)
+    tts.get_file_from_s3_logic = mock_s3_get
+
+    mock_s3_upload = Mock()
+    mock_s3_upload.side_effect = HTTPException(422)
+    tts.upload_file_to_s3_logic = mock_s3_upload
+
+    response = client.get(f"{tts.TTS_ROUTE}?phrase=phrase")
+
+    mock_s3_upload.assert_called_once()
+    assert response.status_code == 200
+    assert response.text == MOCK_AUDIO_BYTES_STR
+
+
+def test_tts_get_data(client: TestClient):
+    """Assert that `get_data` functions as expected."""
+    assert tts.get_data('phrase') == {
+        "text": 'phrase',
+        "model_id": "eleven_monolingual_v1",
+        "voice_settings": {
+            "stability": 0.5,
+            "similarity_boost": 0.5
+        }
+    }
+
+
+def test_tts_get_headers(client: TestClient):
+    """Assert that `get_headers` functions as expected."""
+    assert tts.get_headers({'TTS_API_KEY': 'secret'}) == {
+        "Accept": "audio/mpeg",
+        "Content-Type": "application/json",
+        "xi-api-key": 'secret'
+    }
+
+
+def test_tts_phrase_to_s3_name(client: TestClient):
+    """Assert that `phrase_to_s3_name` functions as expected."""
+    assert tts.phrase_to_s3_name('hello') == 'hello.mp3'
+    assert tts.phrase_to_s3_name('Hello') == 'hello.mp3'
+    assert tts.phrase_to_s3_name(
+        'Wonderful\tday    today  ') == 'wonderfuldaytoday.mp3'
+
+
+def test_get_session(client: TestClient):
+    """Assert that `get_session` returns a requests Session."""
+    assert type(tts.get_session()) == requests.Session
+
+
+def test_get_config(client: TestClient):
+    """Assert that `get_config` returns  the correct type. 
+       We have to assume that dotenv just works, 
+       so this is just for 100% coverage."""
+    assert type(tts.get_config()) == OrderedDict

--- a/backend/src/routers/tts.py
+++ b/backend/src/routers/tts.py
@@ -1,12 +1,15 @@
+import base64
 from functools import cache
-import logging
 import time
 from typing import Annotated
+import urllib.parse
 
 from dotenv import dotenv_values
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Response, HTTPException
 import requests
 
+from .s3_constants import GET_FROM_S3_ROUTE
+from .s3 import get_file_from_s3_logic, upload_file_to_s3_logic
 
 TTS_ROUTE = "/tts"
 
@@ -44,21 +47,49 @@ def get_data(phrase: str) -> dict:
     }
 
 
+def phrase_to_s3_name(phrase: str) -> str:
+    """Lowercases `phrase`, removes all whitespace, and adds the mp3 extension"""
+    return ''.join(phrase.lower().split()) + '.mp3'
+
+
 @router.get(TTS_ROUTE)
 async def tts(phrase: str, config: Annotated[dict, Depends(get_config)], session: Annotated[requests.Session, Depends(get_session)]):
     """
-    Converts **phrase** to audio using elevenlab's test to speech service.
+    Checks if the audio of **phrase** is cached on S3, and returns. If it is
+    not on S3, then it converts **phrase** to audio using elevenlab's test to
+    speech service.
+
     Returns a string of mp3 bytes.
     """
-
     start = time.perf_counter()
-    response = session.post(
-        config["TTS_API_URL"], json=get_data(phrase), headers=get_headers(config))
+
+    audio = None
+
+    try:
+        # Try to fetch from cache
+        print('Trying to get phrase from S3...')
+        (object_content, _) = get_file_from_s3_logic(
+            phrase_to_s3_name(phrase), get_url=False)
+        print('Object found on S3!')
+        audio = b"".join(object_content)
+    except HTTPException:
+        # Cache miss, so we generate a new sound file
+        print('Object not found on S3! Fetching from elevenlabs...')
+        response = session.post(
+            config["TTS_API_URL"], json=get_data(phrase), headers=get_headers(config))
+        response.raise_for_status()
+        audio = b"".join(response.iter_content(chunk_size=1024))
+
+        # Add the new sound file to S3
+        try:
+            upload_file_to_s3_logic(audio, phrase_to_s3_name(phrase), False)
+        except Exception as e:
+            # Even if the upload was unsuccessful,
+            # we still return the audio to the user
+            print(f'Failed to upload phrase audio. {e}')
+
     end = time.perf_counter()
 
-    logging.debug(f"Converting phrase '{phrase}' to audio took {end-start}s.")
+    print(f"Converting phrase '{phrase}' to audio took {end-start}s.")
 
-    response.raise_for_status()
-
-    audio = b"".join(response.iter_content(chunk_size=1024))
     return Response(audio)

--- a/backend/src/routers/tts.py
+++ b/backend/src/routers/tts.py
@@ -1,0 +1,61 @@
+from functools import cache
+import logging
+import time
+from typing import Annotated
+
+from dotenv import dotenv_values
+from fastapi import APIRouter, Depends, Response
+import requests
+
+
+TTS_ROUTE = "/tts"
+
+
+router = APIRouter()
+
+
+@cache
+def get_config():
+    """Returns a dictionary mapping environment variable name to string value."""
+    return dotenv_values(".env.local")
+
+
+@cache
+def get_session():
+    return requests.Session()
+
+
+@router.get(TTS_ROUTE)
+async def tts(phrase: str, config: Annotated[dict, Depends(get_config)], session: Annotated[requests.Session, Depends(get_session)]):
+    """
+    Converts **phrase** to audio using elevenlab's test to speech service.
+    Returns a string of mp3 bytes.
+    """
+    headers = {
+        "Accept": "audio/mpeg",
+        "Content-Type": "application/json",
+        "xi-api-key": config["TTS_API_KEY"]
+    }
+
+    data = {
+        "text": phrase,
+        "model_id": "eleven_monolingual_v1",
+        "voice_settings": {
+            "stability": 0.5,
+            "similarity_boost": 0.5
+        }
+    }
+
+    print(headers)
+
+    start = time.perf_counter()
+    response = session.post(
+        config["TTS_API_URL"], json=data, headers=headers)
+    end = time.perf_counter()
+
+    logging.debug(f"Converting phrase '{phrase}' to audio took {end-start}s.")
+
+    response.raise_for_status()
+
+    audio = b"".join(response.iter_content(chunk_size=1024))
+    return Response(audio)

--- a/backend/src/routers/tts.py
+++ b/backend/src/routers/tts.py
@@ -25,19 +25,16 @@ def get_session():
     return requests.Session()
 
 
-@router.get(TTS_ROUTE)
-async def tts(phrase: str, config: Annotated[dict, Depends(get_config)], session: Annotated[requests.Session, Depends(get_session)]):
-    """
-    Converts **phrase** to audio using elevenlab's test to speech service.
-    Returns a string of mp3 bytes.
-    """
-    headers = {
+def get_headers(config: dict) -> dict:
+    return {
         "Accept": "audio/mpeg",
         "Content-Type": "application/json",
         "xi-api-key": config["TTS_API_KEY"]
     }
 
-    data = {
+
+def get_data(phrase: str) -> dict:
+    return {
         "text": phrase,
         "model_id": "eleven_monolingual_v1",
         "voice_settings": {
@@ -46,11 +43,17 @@ async def tts(phrase: str, config: Annotated[dict, Depends(get_config)], session
         }
     }
 
-    print(headers)
+
+@router.get(TTS_ROUTE)
+async def tts(phrase: str, config: Annotated[dict, Depends(get_config)], session: Annotated[requests.Session, Depends(get_session)]):
+    """
+    Converts **phrase** to audio using elevenlab's test to speech service.
+    Returns a string of mp3 bytes.
+    """
 
     start = time.perf_counter()
     response = session.post(
-        config["TTS_API_URL"], json=data, headers=headers)
+        config["TTS_API_URL"], json=get_data(phrase), headers=get_headers(config))
     end = time.perf_counter()
 
     logging.debug(f"Converting phrase '{phrase}' to audio took {end-start}s.")

--- a/backend/src/test_main.py
+++ b/backend/src/test_main.py
@@ -1,39 +1,15 @@
 import pytest
 from fastapi.testclient import TestClient
-import requests
-import requests_mock
-import httpx # used to add httpx entry to requirements
+import httpx  # used to add httpx entry to requirements
 
-from .main import app, get_config, get_session, Image, ImageResponse, Drawing, DrawingResponse
+from .main import app, Image, ImageResponse, Drawing, DrawingResponse
 
 
-mock_tts_endpoint = 'mock://tts.com'
-mock_text = 'exampledata'
-
-
-def mock_get_config() -> dict:
-    return {
-        'TTS_API_KEY': '',
-        'TTS_API_URL': mock_tts_endpoint
-    }
-
-
-# https://pypi.org/project/requests-mock/
-def mock_get_session() -> dict:
-    session = requests.Session()
-    adapter = requests_mock.Adapter()
-    session.mount(mock_tts_endpoint, adapter)
-    adapter.register_uri('POST', mock_tts_endpoint, text=mock_text)
-    return session
+MOCK_TEXT = 'exampledata'
 
 
 @pytest.fixture
 def client() -> TestClient:
-    app.dependency_overrides.update(
-        {get_config: mock_get_config,
-         get_session: mock_get_session}
-    )
-
     return TestClient(app)
 
 
@@ -52,50 +28,49 @@ def test_healthCheck(client: TestClient):
         "message": "an apple a day keeps the doctor away"}
 
 
-def test_tts(client: TestClient):
-    """Ensure that the client calls the correct endpoint and returns the
-       correct value."""
-    response = client.get("/tts?phrase=phrase")
-    assert response.status_code == 200
-    assert response.text == mock_text
-
 def test_image_output(client: TestClient):
     """Ensure that '/image' returns a list of image predictions (string[])"""
-    image = Image(content=mock_text)
-    imageResponse = ImageResponse(predictions=[mock_text])
+    image = Image(content=MOCK_TEXT)
+    imageResponse = ImageResponse(predictions=[MOCK_TEXT])
     response = client.post("/image", json=image.model_dump())
     assert response.status_code == 200
     assert response.json() == imageResponse.model_dump()
+
 
 def test_image_body_req(client: TestClient):
     """Ensure that '/image' returns an error when there is no request body"""
     response = client.post("/image")
     assert response.status_code == 422
 
+
 def test_image_body_form(client: TestClient):
     """Ensure that '/image' returns an error when the request body is malformed"""
-    image = {"not-content": mock_text}
+    image = {"not-content": MOCK_TEXT}
     response = client.post("/image", json=image)
     assert response.status_code == 422
 
+
 def test_draw_output(client: TestClient):
     """Ensure that '/draw' returns a list of drawing predictions (string[])"""
-    drawing = Drawing(content=mock_text)
-    drawingResponse = DrawingResponse(predictions=[mock_text])
+    drawing = Drawing(content=MOCK_TEXT)
+    drawingResponse = DrawingResponse(predictions=[MOCK_TEXT])
     response = client.post("/draw", json=drawing.model_dump())
     assert response.status_code == 200
     assert response.json() == drawingResponse.model_dump()
+
 
 def test_draw_body_req(client: TestClient):
     """Ensure that '/draw' returns an error when there is no request body"""
     response = client.post("/draw")
     assert response.status_code == 422
 
+
 def test_draw_body_form(client: TestClient):
     """Ensure that '/draw' returns an error when the request body is malformed"""
-    image = {"not-content": mock_text}
+    image = {"not-content": MOCK_TEXT}
     response = client.post("/image", json=image)
     assert response.status_code == 422
+
 
 def test_tile_output(client: TestClient):
     """Ensure that '/tile' correclty outputs the user_id"""


### PR DESCRIPTION
Parth specifically will want to look at the changes in s3.py. I moved the "business logic" for the S3 endpoints into functions so that the TTS endpoint could use them without making a local HTTP request.

Also, the unit tests use a manual form of monkeypatching to mock functions called in the tts endpoint because I failed to get the pytest feature to work. Any feedback on lines such as line 85: "tts.get_file_from_s3_logic = mock_s3_get" would be appreciated.