### PR TITLE
Ss 103 debug issues running camera recognition on mobile

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,8 +54,6 @@
 
                 "react-icons": "^4.11.0",
 
-                "react-webcam": "^7.2.0",
-
                 "standardized-audio-context": "^25.3.57",
 
                 "tailwindcss": "3.3.3",
@@ -22137,24 +22135,6 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-
-        },
-
-        "node_modules/react-webcam": {
-
-            "version": "7.2.0",
-
-            "resolved": "https://registry.npmjs.org/react-webcam/-/react-webcam-7.2.0.tgz",
-
-            "integrity": "sha512-xkrzYPqa1ag2DP+2Q/kLKBmCIfEx49bVdgCCCcZf88oF+0NPEbkwYk3/s/C7Zy0mhM8k+hpdNkBLzxg8H0aWcg==",
-
-            "peerDependencies": {
-
-                "react": ">=16.2.0",
-
-                "react-dom": ">=16.2.0"
-
-            }
 
         },
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,8 +58,6 @@
 
         "react-icons": "^4.11.0",
 
-        "react-webcam": "^7.2.0",
-
         "standardized-audio-context": "^25.3.57",
 
         "tailwindcss": "3.3.3",

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -90,14 +90,14 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
         ref={videoPlayer}
         width={props.width}
         height={props.height}
-        // style={{ position: "absolute", top: "-10000px" }} // Hide from user's eyes
+        style={{ position: "absolute", top: "-10000px" }} // Hide from user's eyes
         playsInline={true}
       />
       <canvas
         width={props.width}
         height={props.height}
         ref={canvas}
-        // style={{ position: "absolute", top: "-10000px" }}
+        style={{ position: "absolute", top: "-10000px" }}
       />
     </>
   );

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -1,9 +1,9 @@
 import React, {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
-  useState,
 } from "react";
 
 type CameraFeedProps = {
@@ -21,8 +21,6 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
 ) {
   const videoPlayer = useRef<HTMLVideoElement>(null);
   const canvas = useRef<HTMLCanvasElement>(null);
-
-  const { cameraNum } = props;
 
   /**
    * Sets the active device and starts playing the feed
@@ -43,10 +41,10 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
   /**
    * Processes available devices and identifies one by the label
    */
-  const processDevices = (devices: MediaDeviceInfo[]) => {
+  const processDevices = useCallback((devices: MediaDeviceInfo[]) => {
     const videoDevices = devices.filter((info) => info.kind == "videoinput");
-    setDevice(videoDevices[cameraNum % videoDevices.length]);
-  };
+    setDevice(videoDevices[props.cameraNum % videoDevices.length]);
+  }, [props.cameraNum]);
 
   // On component mounting, we want to select a camera to take pictures from
   useEffect(() => {
@@ -60,8 +58,6 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
    * Handles taking a still image from the video feed on the camera
    */
   const getScreenshot = () => {
-    console.log(cameraNum);
-
     if (!canvas.current) return;
     const context = canvas.current.getContext("2d");
 

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -40,24 +40,13 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
     videoPlayer.current.play();
   };
 
-  /**
-   * Processes available devices and identifies one by the label
-   */
-  const processDevices = useCallback(
-    (devices: MediaDeviceInfo[]) => {
-      const videoDevices = devices.filter((info) => info.kind == "videoinput");
-      console.log(videoDevices);
-      console.log(videoDevices[props.cameraNum % videoDevices.length]);
-      setDevice(videoDevices[props.cameraNum % videoDevices.length]);
-    },
-    [props.cameraNum]
-  );
-
   // On component mounting, we want to select a camera to take pictures from
   useEffect(() => {
     (async () => {
       const cameras = await navigator.mediaDevices.enumerateDevices();
-      processDevices(cameras);
+
+      const videoDevices = cameras.filter((info) => info.kind == "videoinput");
+      setDevice(videoDevices[props.cameraNum % videoDevices.length]);
     })();
   }, [props.cameraNum]);
 

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -1,11 +1,21 @@
-import React, { useEffect, useRef } from "react";
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
 
-interface CameraFeedProps {
-  sendFile: (url: string) => void;
-}
+type CameraFeedProps = {};
+
+export type GetScreenshotHandle = {
+  getScreenshot: () => string;
+};
 
 /** Courtesy of https://codesandbox.io/p/sandbox/74pzm9lkq6?file=%2Fsrc%2Fcomponents%2Fcamera-feed.jsx%3A60%2C23 */
-export default function CameraFeed(props: CameraFeedProps) {
+const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
+  props,
+  ref
+) {
   const videoPlayer = useRef<HTMLVideoElement>(null);
   const canvas = useRef<HTMLCanvasElement>(null);
 
@@ -51,9 +61,7 @@ export default function CameraFeed(props: CameraFeedProps) {
    * @memberof CameraFeed
    * @instance
    */
-  const takePhoto = () => {
-    const { sendFile } = props;
-
+  const getScreenshot = () => {
     if (!canvas.current) return;
     const context = canvas.current.getContext("2d");
 
@@ -61,18 +69,31 @@ export default function CameraFeed(props: CameraFeedProps) {
     if (!context) return;
     context.drawImage(videoPlayer.current, 0, 0, 680, 360);
     const url = canvas.current.toDataURL();
-    sendFile(url);
+    return url;
   };
+
+  // https://stackoverflow.com/a/69292925
+  useImperativeHandle(
+    ref,
+    () => ({
+      getScreenshot() {
+        return getScreenshot() ?? "";
+      },
+    }),
+    []
+  );
 
   return (
     <div className="c-camera-feed">
       <div className="c-camera-feed__viewer">
         <video ref={videoPlayer} width="680" height="360" />
       </div>
-      <button onClick={takePhoto}>Take photo!</button>
+      <button onClick={getScreenshot}>Take photo!</button>
       <div className="c-camera-feed__stage">
         <canvas width="680" height="360" ref={canvas} />
       </div>
     </div>
   );
-}
+});
+
+export default CameraFeed;

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
 
 interface CameraFeedProps {
-  sendFile: BlobCallback;
+  sendFile: (url: string) => void;
 }
 
 /** Courtesy of https://codesandbox.io/p/sandbox/74pzm9lkq6?file=%2Fsrc%2Fcomponents%2Fcamera-feed.jsx%3A60%2C23 */
@@ -60,7 +60,8 @@ export default function CameraFeed(props: CameraFeedProps) {
     if (!videoPlayer.current) return;
     if (!context) return;
     context.drawImage(videoPlayer.current, 0, 0, 680, 360);
-    canvas.current.toBlob(sendFile);
+    const url = canvas.current.toDataURL();
+    sendFile(url);
   };
 
   return (

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -8,6 +8,8 @@ import React, {
 
 type CameraFeedProps = {
   cameraNum: number;
+  width: number;
+  height: number;
 };
 
 export type GetScreenshotHandle = {
@@ -41,10 +43,13 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
   /**
    * Processes available devices and identifies one by the label
    */
-  const processDevices = useCallback((devices: MediaDeviceInfo[]) => {
-    const videoDevices = devices.filter((info) => info.kind == "videoinput");
-    setDevice(videoDevices[props.cameraNum % videoDevices.length]);
-  }, [props.cameraNum]);
+  const processDevices = useCallback(
+    (devices: MediaDeviceInfo[]) => {
+      const videoDevices = devices.filter((info) => info.kind == "videoinput");
+      setDevice(videoDevices[props.cameraNum % videoDevices.length]);
+    },
+    [props.cameraNum]
+  );
 
   // On component mounting, we want to select a camera to take pictures from
   useEffect(() => {
@@ -63,7 +68,13 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
 
     if (!videoPlayer.current) return;
     if (!context) return;
-    context.drawImage(videoPlayer.current, 0, 0, 680, 360);
+    context.drawImage(
+      videoPlayer.current,
+      0,
+      0,
+      videoPlayer.current.videoWidth,
+      videoPlayer.current.videoHeight
+    );
     const url = canvas.current.toDataURL();
 
     return url;
@@ -85,15 +96,15 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
     <>
       <video
         ref={videoPlayer}
-        width="1024"
-        height="768"
-        style={{ position: "absolute", top: "-10000px" }} // Hide from user's eyes
+        width={props.width}
+        height={props.height}
+        // style={{ position: "absolute", top: "-10000px" }} // Hide from user's eyes
       />
       <canvas
-        width="1024"
-        height="768"
+        width={props.width}
+        height={props.height}
         ref={canvas}
-        style={{ position: "absolute", top: "-10000px" }}
+        // style={{ position: "absolute", top: "-10000px" }}
       />
     </>
   );

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef } from "react";
+
+interface CameraFeedProps {
+  sendFile: BlobCallback;
+}
+
+/** Courtesy of https://codesandbox.io/p/sandbox/74pzm9lkq6?file=%2Fsrc%2Fcomponents%2Fcamera-feed.jsx%3A60%2C23 */
+export default function CameraFeed(props: CameraFeedProps) {
+  const videoPlayer = useRef<HTMLVideoElement>(null);
+  const canvas = useRef<HTMLCanvasElement>(null);
+
+  /**
+   * Sets the active device and starts playing the feed
+   * @memberof CameraFeed
+   * @instance
+   */
+  const setDevice = async (device: MediaDeviceInfo) => {
+    if (!videoPlayer.current) return;
+
+    const { deviceId } = device;
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: false,
+      video: { deviceId },
+    });
+
+    videoPlayer.current.srcObject = stream;
+    videoPlayer.current.play();
+  };
+
+  /**
+   * Processes available devices and identifies one by the label
+   * @memberof CameraFeed
+   * @instance
+   */
+  const processDevices = (devices: MediaDeviceInfo[]) => {
+    devices.forEach((device) => {
+      console.log(device.label);
+      setDevice(device);
+    });
+  };
+
+  useEffect(() => {
+    (async () => {
+      const cameras = await navigator.mediaDevices.enumerateDevices();
+      processDevices(cameras);
+    })();
+  }, []);
+
+  /**
+   * Handles taking a still image from the video feed on the camera
+   * @memberof CameraFeed
+   * @instance
+   */
+  const takePhoto = () => {
+    const { sendFile } = props;
+
+    if (!canvas.current) return;
+    const context = canvas.current.getContext("2d");
+
+    if (!videoPlayer.current) return;
+    if (!context) return;
+    context.drawImage(videoPlayer.current, 0, 0, 680, 360);
+    canvas.current.toBlob(sendFile);
+  };
+
+  return (
+    <div className="c-camera-feed">
+      <div className="c-camera-feed__viewer">
+        <video ref={videoPlayer} width="680" height="360" />
+      </div>
+      <button onClick={takePhoto}>Take photo!</button>
+      <div className="c-camera-feed__stage">
+        <canvas width="680" height="360" ref={canvas} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -46,6 +46,8 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
   const processDevices = useCallback(
     (devices: MediaDeviceInfo[]) => {
       const videoDevices = devices.filter((info) => info.kind == "videoinput");
+      console.log(videoDevices);
+      console.log(videoDevices[props.cameraNum % videoDevices.length]);
       setDevice(videoDevices[props.cameraNum % videoDevices.length]);
     },
     [props.cameraNum]
@@ -57,7 +59,7 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
       const cameras = await navigator.mediaDevices.enumerateDevices();
       processDevices(cameras);
     })();
-  }, []);
+  }, [props.cameraNum]);
 
   /**
    * Handles taking a still image from the video feed on the camera
@@ -99,6 +101,7 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
         width={props.width}
         height={props.height}
         // style={{ position: "absolute", top: "-10000px" }} // Hide from user's eyes
+        playsInline={true}
       />
       <canvas
         width={props.width}

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -84,15 +84,20 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
   );
 
   return (
-    <div className="c-camera-feed">
-      <div className="c-camera-feed__viewer">
-        <video ref={videoPlayer} width="680" height="360" />
-      </div>
-      <button onClick={getScreenshot}>Take photo!</button>
-      <div className="c-camera-feed__stage">
-        <canvas width="680" height="360" ref={canvas} />
-      </div>
-    </div>
+    <>
+      <video
+        ref={videoPlayer}
+        width="1024"
+        height="768"
+        style={{ position: "absolute", top: "-10000px" }}
+      />
+      <canvas
+        width="1024"
+        height="768"
+        ref={canvas}
+        style={{ position: "absolute", top: "-10000px" }}
+      />
+    </>
   );
 });
 

--- a/frontend/src/react-state-management/providers/CameraFeed.tsx
+++ b/frontend/src/react-state-management/providers/CameraFeed.tsx
@@ -57,8 +57,8 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
     if (!canvas.current) return;
     const context = canvas.current.getContext("2d");
 
-    if (!videoPlayer.current) return;
-    if (!context) return;
+    if (!videoPlayer.current || !context) return;
+
     context.drawImage(
       videoPlayer.current,
       0,
@@ -66,6 +66,7 @@ const CameraFeed = forwardRef<GetScreenshotHandle, CameraFeedProps>(function (
       videoPlayer.current.videoWidth,
       videoPlayer.current.videoHeight
     );
+
     const url = canvas.current.toDataURL();
 
     return url;

--- a/frontend/src/react-state-management/providers/useRekognition.tsx
+++ b/frontend/src/react-state-management/providers/useRekognition.tsx
@@ -15,7 +15,7 @@ import useTimedIncrement from "@/react-helpers/hooks/useTimedIncrement";
 import { getAACAssets } from "@/util/AAC/getAACAssets";
 import { useTilesProvider } from "./tileProvider";
 import { TileProps } from "@/components/AAC/Tile";
-import CameraFeed from "./CameraFeed";
+import CameraFeed, { GetScreenshotHandle } from "./CameraFeed";
 
 const RekognitionContext = createContext<RekognitionState>({
   items: [],
@@ -39,7 +39,7 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
   const [debug, setDebug] = useState<string>("");
 
   // webcam state
-  const webcamRef = useRef<Webcam>(null);
+  const webcamRef = useRef<GetScreenshotHandle>(null);
   const [imgSrc, setImgSrc] = useState<string | null>(null);
   const facingMode =
     refresh % 2 == 0 ? FACING_MODE_USER : FACING_MODE_ENVIRONMENT; //swap cams every image
@@ -84,11 +84,7 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
 
   return (
     <RekognitionContext.Provider value={value}>
-      <CameraFeed
-        sendFile={(url: string) => {
-          console.log(url);
-        }}
-      />
+      <CameraFeed ref={webcamRef} />
       {props.children}
       <p>{debug}</p>
     </RekognitionContext.Provider>

--- a/frontend/src/react-state-management/providers/useRekognition.tsx
+++ b/frontend/src/react-state-management/providers/useRekognition.tsx
@@ -12,10 +12,10 @@ import {
   sendImageToBackendForLabeling,
 } from "./useRekognitionUtil";
 import useTimedIncrement from "@/react-helpers/hooks/useTimedIncrement";
-import Webcam from "react-webcam";
 import { getAACAssets } from "@/util/AAC/getAACAssets";
 import { useTilesProvider } from "./tileProvider";
 import { TileProps } from "@/components/AAC/Tile";
+import CameraFeed from "./CameraFeed";
 
 const RekognitionContext = createContext<RekognitionState>({
   items: [],
@@ -84,17 +84,7 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
 
   return (
     <RekognitionContext.Provider value={value}>
-      <Webcam
-        muted={false}
-        width={0}
-        height={0}
-        ref={webcamRef}
-        style={{ position: "absolute", top: "-10000px" }}
-        screenshotFormat={MIME_TYPE}
-        minScreenshotHeight={768}
-        minScreenshotWidth={1024}
-        videoConstraints={{ facingMode }}
-      />
+      <CameraFeed sendFile={() => {}} />
       {props.children}
       <p>{debug}</p>
     </RekognitionContext.Provider>

--- a/frontend/src/react-state-management/providers/useRekognition.tsx
+++ b/frontend/src/react-state-management/providers/useRekognition.tsx
@@ -21,7 +21,7 @@ const RekognitionContext = createContext<RekognitionState>({
 });
 
 export const MIME_TYPE = "image/png";
-export const INCREMENT_INTERVAL = 10000
+export const INCREMENT_INTERVAL = 10000;
 
 export const useRekognition = () => useContext(RekognitionContext);
 
@@ -54,10 +54,12 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
   useEffect(() => {
     capture();
 
-    setCameraNum(prevNum => prevNum + 1)
+    setCameraNum((prevNum) => prevNum + 1);
   }, [refresh]);
 
-  useEffect(() => {console.log({cameraNum})}, [cameraNum])
+  useEffect(() => {
+    console.log({ cameraNum });
+  }, [cameraNum]);
 
   useEffect(() => {
     if (!imgSrc) return;
@@ -86,7 +88,12 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
 
   return (
     <RekognitionContext.Provider value={value}>
-      <CameraFeed ref={webcamRef} cameraNum={cameraNum} />
+      <CameraFeed
+        ref={webcamRef}
+        cameraNum={cameraNum}
+        width={768}
+        height={1024}
+      />
       {props.children}
       <p>{debug}</p>
     </RekognitionContext.Provider>

--- a/frontend/src/react-state-management/providers/useRekognition.tsx
+++ b/frontend/src/react-state-management/providers/useRekognition.tsx
@@ -49,16 +49,14 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
 
     const imageSrc = webcamRef.current.getScreenshot();
     setImgSrc(imageSrc);
-  }, [webcamRef]);
-
-  useEffect(() => {
-    capture();
 
     // After we capture, we want to increment the camera number to
     // signal CameraFeed to use a different device
-    return function () {
-      setCameraNum(cameraNum + 1);
-    };
+    setCameraNum((cameraNum) => cameraNum + 1);
+  }, [webcamRef, cameraNum]);
+
+  useEffect(() => {
+    capture();
   }, [refresh]);
 
   useEffect(() => {

--- a/frontend/src/react-state-management/providers/useRekognition.tsx
+++ b/frontend/src/react-state-management/providers/useRekognition.tsx
@@ -84,7 +84,11 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
 
   return (
     <RekognitionContext.Provider value={value}>
-      <CameraFeed sendFile={() => {}} />
+      <CameraFeed
+        sendFile={(url: string) => {
+          console.log(url);
+        }}
+      />
       {props.children}
       <p>{debug}</p>
     </RekognitionContext.Provider>

--- a/frontend/src/react-state-management/providers/useRekognition.tsx
+++ b/frontend/src/react-state-management/providers/useRekognition.tsx
@@ -1,5 +1,16 @@
-import React, { createContext, useContext, useState, useRef, useCallback, useEffect } from "react";
-import { RekognitionProviderProps, RekognitionState, sendImageToBackendForLabeling } from "./useRekognitionUtil";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+} from "react";
+import {
+  RekognitionProviderProps,
+  RekognitionState,
+  sendImageToBackendForLabeling,
+} from "./useRekognitionUtil";
 import useTimedIncrement from "@/react-helpers/hooks/useTimedIncrement";
 import Webcam from "react-webcam";
 import { getAACAssets } from "@/util/AAC/getAACAssets";
@@ -7,7 +18,7 @@ import { useTilesProvider } from "./tileProvider";
 import { TileProps } from "@/components/AAC/Tile";
 
 const RekognitionContext = createContext<RekognitionState>({
-    items: [],
+  items: [],
 });
 
 export const useRekognition = () => useContext(RekognitionContext);
@@ -17,68 +28,75 @@ const FACING_MODE_ENVIRONMENT = "environment";
 export const MIME_TYPE = "image/png";
 
 export default function RekognitionProvider(props: RekognitionProviderProps) {
-    // read tiles
-    const { flatList } = useTilesProvider();
+  // read tiles
+  const { flatList } = useTilesProvider();
 
-    // provider state
-    const [items, setItems] = useState<TileProps[]>([]); // items reterived from image detection
-    const refresh = useTimedIncrement(10000);
+  // provider state
+  const [items, setItems] = useState<TileProps[]>([]); // items reterived from image detection
+  const refresh = useTimedIncrement(10000);
 
-    //! debug
-    const [debug, setDebug] = useState<string>("");
+  //! debug
+  const [debug, setDebug] = useState<string>("");
 
-    // webcam state
-    const webcamRef = useRef<Webcam>(null);
-    const [imgSrc, setImgSrc] = useState<string | null>(null);
-    const facingMode = refresh % 2 == 0 ? FACING_MODE_USER : FACING_MODE_ENVIRONMENT; //swap cams every image
+  // webcam state
+  const webcamRef = useRef<Webcam>(null);
+  const [imgSrc, setImgSrc] = useState<string | null>(null);
+  const facingMode =
+    refresh % 2 == 0 ? FACING_MODE_USER : FACING_MODE_ENVIRONMENT; //swap cams every image
 
-    // create a capture function
-    const capture = useCallback(() => {
-        if (!webcamRef.current) return;
+  // create a capture function
+  const capture = useCallback(() => {
+    console.log("In capture");
+    if (!webcamRef.current) return;
 
-        const imageSrc = webcamRef.current.getScreenshot();
-        setImgSrc(imageSrc);
-    }, [webcamRef]);
+    const imageSrc = webcamRef.current.getScreenshot();
+    setImgSrc(imageSrc);
+  }, [webcamRef]);
 
-    useEffect(() => {
-        capture();
-    }, [refresh]);
+  useEffect(() => {
+    capture();
+  }, [refresh]);
 
-    useEffect(() => {
-        if (!imgSrc) return;
+  useEffect(() => {
+    if (!imgSrc) return;
 
-        const labelDetectionAction = sendImageToBackendForLabeling(imgSrc, MIME_TYPE);
-
-        labelDetectionAction.then((detectionResponse) => {
-            if (!detectionResponse) return;
-
-            console.log("server detection resp:", detectionResponse);
-            setDebug(JSON.stringify(detectionResponse, null, 2));
-            const detectedTiles = detectionResponse.map((item) => flatList[item.name]).filter((item) => item);
-
-            setItems(detectedTiles);
-        });
-    }, [imgSrc]);
-
-    const value = {
-        items,
-    };
-
-    return (
-        <RekognitionContext.Provider value={value}>
-            <Webcam
-                muted={false}
-                width={0}
-                height={0}
-                ref={webcamRef}
-                style={{ position: "absolute", top: "-10000px" }}
-                screenshotFormat={MIME_TYPE}
-                minScreenshotHeight={768}
-                minScreenshotWidth={1024}
-                videoConstraints={{ facingMode }}
-            />
-            {props.children}
-            <p>{debug}</p>
-        </RekognitionContext.Provider>
+    const labelDetectionAction = sendImageToBackendForLabeling(
+      imgSrc,
+      MIME_TYPE
     );
+
+    labelDetectionAction.then((detectionResponse) => {
+      if (!detectionResponse) return;
+
+      console.log("server detection resp:", detectionResponse);
+      setDebug(JSON.stringify(detectionResponse, null, 2));
+      const detectedTiles = detectionResponse
+        .map((item) => flatList[item.name])
+        .filter((item) => item);
+
+      setItems(detectedTiles);
+    });
+  }, [imgSrc]);
+
+  const value = {
+    items,
+  };
+
+  return (
+    <RekognitionContext.Provider value={value}>
+      <Webcam
+        muted={false}
+        width={0}
+        height={0}
+        ref={webcamRef}
+        style={{ position: "absolute", top: "-10000px" }}
+        screenshotFormat={MIME_TYPE}
+        minScreenshotHeight={768}
+        minScreenshotWidth={1024}
+        videoConstraints={{ facingMode }}
+      />
+      {props.children}
+      <p>{debug}</p>
+    </RekognitionContext.Provider>
+  );
 }

--- a/frontend/src/react-state-management/providers/useRekognition.tsx
+++ b/frontend/src/react-state-management/providers/useRekognition.tsx
@@ -47,7 +47,6 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
   const capture = useCallback(() => {
     if (!webcamRef.current) return;
     const imageSrc = webcamRef.current.getScreenshot();
-    console.log("In capture", imageSrc);
     setImgSrc(imageSrc);
   }, [webcamRef]);
 
@@ -56,10 +55,6 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
 
     setCameraNum((prevNum) => prevNum + 1);
   }, [refresh]);
-
-  useEffect(() => {
-    console.log({ cameraNum });
-  }, [cameraNum]);
 
   useEffect(() => {
     if (!imgSrc) return;

--- a/frontend/src/react-state-management/providers/useRekognition.tsx
+++ b/frontend/src/react-state-management/providers/useRekognition.tsx
@@ -20,9 +20,10 @@ const RekognitionContext = createContext<RekognitionState>({
   items: [],
 });
 
-export const useRekognition = () => useContext(RekognitionContext);
-
 export const MIME_TYPE = "image/png";
+export const INCREMENT_INTERVAL = 10000
+
+export const useRekognition = () => useContext(RekognitionContext);
 
 export default function RekognitionProvider(props: RekognitionProviderProps) {
   // read tiles
@@ -30,7 +31,7 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
 
   // provider state
   const [items, setItems] = useState<TileProps[]>([]); // items reterived from image detection
-  const refresh = useTimedIncrement(10000);
+  const refresh = useTimedIncrement(INCREMENT_INTERVAL);
 
   //! debug
   const [debug, setDebug] = useState<string>("");
@@ -44,20 +45,19 @@ export default function RekognitionProvider(props: RekognitionProviderProps) {
 
   // create a capture function
   const capture = useCallback(() => {
-    console.log("In capture");
     if (!webcamRef.current) return;
-
     const imageSrc = webcamRef.current.getScreenshot();
+    console.log("In capture", imageSrc);
     setImgSrc(imageSrc);
-
-    // After we capture, we want to increment the camera number to
-    // signal CameraFeed to use a different device
-    setCameraNum((cameraNum) => cameraNum + 1);
-  }, [webcamRef, cameraNum]);
+  }, [webcamRef]);
 
   useEffect(() => {
     capture();
+
+    setCameraNum(prevNum => prevNum + 1)
   }, [refresh]);
+
+  useEffect(() => {console.log({cameraNum})}, [cameraNum])
 
   useEffect(() => {
     if (!imgSrc) return;


### PR DESCRIPTION
There is one problem with this solution: it doesn't get EXIF data when pictures are taken on iOS so we don't know the orientation. Also, Safari doesn't support the JS APIs for getting screen orientation until 16.4 which many devices don't have yet (it was released in 2022). It looks like Rekognition doesn't mind the rotation, and Image recognition models are usually trained with random rotations, so it should be fine.